### PR TITLE
Restricted wavefunction norm adjustment to exponential activations

### DIFF
--- a/cgs_vmc/normalizer.py
+++ b/cgs_vmc/normalizer.py
@@ -41,6 +41,8 @@ def normalize_wavefunction(
   set_norm_on_batch = wavefunction.normalize_batch(psi_value, value)
   update_norm_on_batch = wavefunction.update_norm(psi_value, value)
 
+  if not set_norm_on_batch:
+    return
   session.run(set_norm_on_batch)
   for _ in range(normalization_iterations):
     session.run(update_config)


### PR DESCRIPTION
Temporarily adjusted the wave wave-function norm is adjusted to prevent potential overflows. Now testing output_activations such as identity should work without any side effects, as they will not generate any shifts.